### PR TITLE
Fix variable may be uninitialized

### DIFF
--- a/src/jrd/inf.cpp
+++ b/src/jrd/inf.cpp
@@ -177,7 +177,7 @@ void INF_blob_info(const blb* blob,
 	CHECK_INPUT("INF_blob_info");
 
 	UCHAR buffer[BUFFER_TINY];
-	USHORT length;
+	USHORT length = 0;
 
 	const UCHAR* const end_items = items + item_length;
 	const UCHAR* const end = info + output_length;
@@ -289,7 +289,7 @@ void INF_database_info(thread_db* tdbb,
 
 	CountsBuffer counts_buffer;
 	UCHAR* buffer = counts_buffer.getBuffer(BUFFER_SMALL, false);
-	ULONG length, err_val;
+	ULONG length = 0, err_val = 0;
 	bool header_refreshed = false;
 
 	Database* const dbb = tdbb->getDatabase();
@@ -778,7 +778,7 @@ void INF_database_info(thread_db* tdbb,
 		case fb_info_page_contents:
 			{
 				bool validArgs = false;
-				ULONG pageNum;
+				ULONG pageNum = 0;
 
 				if (end_items - items >= 2)
 				{
@@ -1196,7 +1196,7 @@ void INF_transaction_info(const jrd_tra* transaction,
 	CHECK_INPUT("INF_transaction_info");
 
 	UCHAR buffer[MAXPATHLEN];
-	ULONG length;
+	ULONG length = 0;
 
 	const UCHAR* const end_items = items + item_length;
 	const UCHAR* const end = info + output_length;

--- a/src/jrd/intl.cpp
+++ b/src/jrd/intl.cpp
@@ -818,7 +818,7 @@ void INTL_convert_string(dsc* to, const dsc* from, Firebird::Callbacks* cb)
 		reinterpret_cast<UCHAR*>(((vary*) p)->vary_string) :
 		p;
 
-	ULONG to_fill;
+	ULONG to_fill = 0;
 
 	if (from_cs != to_cs && to_cs != CS_BINARY && to_cs != CS_NONE && from_cs != CS_NONE)
 	{

--- a/src/remote/server/server.cpp
+++ b/src/remote/server/server.cpp
@@ -4652,7 +4652,7 @@ void rem_port::info(P_OP op, P_INFO* stuff, PACKET* sendL)
 
 	HalfStaticArray<UCHAR, 1024> info;
 	UCHAR* info_buffer = NULL;
-	ULONG info_len;
+	ULONG info_len = 0;
 	HalfStaticArray<UCHAR, 1024> temp;
 	UCHAR* temp_buffer = NULL;
 
@@ -6130,8 +6130,8 @@ bool rem_port::sendInlineBlob(PACKET* sendL, Rtr* rtr, SQUAD blobId, ULONG maxSi
 		return false;
 
 	bool segmented;
-	ULONG num_segments;
-	ULONG max_segment;
+	ULONG num_segments = 0;
+	ULONG max_segment = 0;
 	FB_UINT64 total_length;
 
 	ClumpletReader p(ClumpletReader::InfoResponse, info, sizeof(info));


### PR DESCRIPTION
List of fixed warnings:

a6d54ce0521711836d961a9f0cf6458d
a6d54ce0521711836d961a9f0cf6458d
b6a20ccf10a7193fd2bb18af4db4ce0f
12a21acf9cf6cc001772936ef55089f5
78db54c0e1a9d1d7ca757e9327098618
c194d8289ec3ca24744fac51f964d08e
d0386241facbc016928823d5778dc60d