### PR TITLE
Fixed pointer that should not be dereferenced

### DIFF
--- a/src/common/isc_sync.cpp
+++ b/src/common/isc_sync.cpp
@@ -1438,7 +1438,7 @@ SharedMemoryBase::SharedMemoryBase(const TEXT* filename, ULONG length, IpcObject
 #endif
 #endif
 
-				memset(sh_mem_mutex->mtx_mutex, 0, sizeof(*(sh_mem_mutex->mtx_mutex)));
+				memset(sh_mem_mutex->mtx_mutex, 0, sizeof(sh_mem_mutex->mtx_mutex));
 				//int state = LOG_PTHREAD_ERROR(pthread_mutex_init(sh_mem_mutex->mtx_mutex, &mattr));
 				state = pthread_mutex_init(sh_mem_mutex->mtx_mutex, &mattr);
 


### PR DESCRIPTION
Fixed warning: 9651f64c1125047e6e169854fdabe490