### PR TITLE
Fix null pointer dereference

### DIFF
--- a/src/common/CsConvert.h
+++ b/src/common/CsConvert.h
@@ -197,6 +197,10 @@ public:
 			return len;
 		}
 
+        // I'm not sure this is the correct handling of this error
+        if(!cnvt1)
+			raiseError(isc_transliteration_failed);
+
 		const ULONG len = (*cnvt1->csconvert_fn_convert)(
 			cnvt1, srcLen, src, dstLen, dst, &errCode, &errPos);
 

--- a/src/jrd/met.epp
+++ b/src/jrd/met.epp
@@ -5276,8 +5276,8 @@ void MET_store_dependencies(thread_db* tdbb,
 	{
 		CompilerScratch::Dependency dependency = dependencies.pop();
 
-		if (!dependency.relation && !dependency.function && !dependency.procedure &&
-			!dependency.name && !dependency.number)
+		if (!dependency.relation || !dependency.function || !dependency.procedure ||
+			!dependency.name || !dependency.number)
 		{
 			continue;
 		}


### PR DESCRIPTION
Fixed warnings:
a9dea0c45527292d475541e69c8fdf13
e9f22b43135dbdac5e0b0fcb720eec10
ba6816c30d43232efcce21142f9b9bdf
