### PR TITLE
Fixed forming reference to null pointer 

### DIFF
--- a/src/jrd/vio.cpp
+++ b/src/jrd/vio.cpp
@@ -7296,7 +7296,7 @@ void VIO_update_in_place(thread_db* tdbb,
 	{
 		stack = &new_rpb->rpb_record->getPrecedence();
 	}
-	else if (org_rpb->rpb_record) // we apply update to delete stub
+	else // we apply update to delete stub
 	{
 		stack = &org_rpb->rpb_record->getPrecedence();
 	}


### PR DESCRIPTION
According to comment (line 7303) 'stack' will unavoidable be assigned, so 'else if' statement was changed to 'else' to ensure assignment

Warning hash: fb069124c7efa598a06192aac402ff26