### PR TITLE
Uninitialized warns fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ extern/ttmath/release/
 /src/include/gen/autoconfig.h
 extern/libcds/lib/
 /vcpkg_installed/
+reports/
+report_html/
+skipfile.txt
+codechecker.yaml
+codechecker_build.json

--- a/src/common/sdl.cpp
+++ b/src/common/sdl.cpp
@@ -511,7 +511,7 @@ static bool execute(sdl_arg* arg)
  *
  **************************************/
 	SLONG* variable;
-	SLONG stack[64];
+	SLONG stack[64]{0};
 	SLONG value, count;
 	dsc element_desc;
 
@@ -536,23 +536,39 @@ static bool execute(sdl_arg* arg)
 			break;
 
 		case op_add:
-			value = *stack_ptr++;
-			*stack_ptr += value;
+			if (stack_ptr >= stack + FB_NELEM(stack) - 1) {
+				return false;
+			}
+			value = stack_ptr[0];
+			stack_ptr[1] += value;
+			stack_ptr++;
 			break;
 
 		case op_subtract:
-			value = *stack_ptr++;
-			*stack_ptr -= value;
+			if (stack_ptr >= stack + FB_NELEM(stack) - 1) {
+				return false;
+			}
+			value = stack_ptr[0];
+			stack_ptr[1] -= value;
+			stack_ptr++;
 			break;
 
 		case op_multiply:
-			value = *stack_ptr++;
-			*stack_ptr *= value;
+			if (stack_ptr >= stack + FB_NELEM(stack) - 1) {
+				return false;
+			}
+			value = stack_ptr[0];
+			stack_ptr[1] *= value;
+			stack_ptr++;
 			break;
 
 		case op_divide:
-			value = *stack_ptr++;
-			*stack_ptr /= value;
+			if (stack_ptr >= stack + FB_NELEM(stack) - 1) {
+				return false;
+			}
+			value = stack_ptr[0];
+			stack_ptr[1] /= value;
+			stack_ptr++;
 			break;
 
 		case op_goto:

--- a/src/dsql/ExprNodes.cpp
+++ b/src/dsql/ExprNodes.cpp
@@ -10087,6 +10087,10 @@ dsc* ParameterNode::execute(thread_db* tdbb, Request* request) const
 						len = reinterpret_cast<const vary*>(p)->vary_length;
 						p += sizeof(USHORT);
 						break;
+
+					delete:
+						len = 0;
+						break;
 				}
 
 				auto charSet = INTL_charset_lookup(tdbb, DSC_GET_CHARSET(retDesc));


### PR DESCRIPTION
Errors related to **_uninitialized data_** have been fixed. Hashes of the corrected errors are attached:

http://localhost:8001/Default/reports?report-hash=2c922769b2fb516cafd74e95795029df
http://localhost:8001/Default/reports?report-hash=3917bee9a389480226a200dfd8c68b45
http://localhost:8001/Default/reports?report-hash=fe6054b0ea8831539f225e1987375a39
http://localhost:8001/Default/reports?report-hash=88b693ec55d629e0558e000f8f82d3b6
http://localhost:8001/Default/reports?report-hash=ad9679bfd6b06d3aa76e4df3d6c518cf
