### PR TITLE
Fix/warnings 2

### DIFF
--- a/src/jrd/trace/TraceCmdLine.cpp
+++ b/src/jrd/trace/TraceCmdLine.cpp
@@ -434,6 +434,8 @@ void fbtrace(UtilSvc* uSvc, TraceSvcIntf* traceSvc)
 			case IN_SW_TRACE_RESUME:
 				usage(uSvc, isc_trace_switch_param_miss, "ID", action_sw->in_sw_name);
 				break;
+			default:
+				fb_assert(false);
 		}
 	}
 

--- a/src/jrd/trace/TraceCmdLine.cpp
+++ b/src/jrd/trace/TraceCmdLine.cpp
@@ -62,10 +62,7 @@ namespace
 		static const SafeArg dummy;
 		printMsg(number, dummy, newLine);
 	}
-// All MessageSet instances below (MAIN_USAGE, EXAMPLES) are initialized with
-// message codes in range 3..42, which fits well within USHORT (0..65535).
-// See usages below: MAIN_USAGE{{3, 21}, {41}}, EXAMPLES{{22, 27}, {42}}.
-// If new codes are added, make sure they still fit into USHORT.
+
 	struct MessageSet
 	{
 		const int range[2];

--- a/src/jrd/trace/TraceCmdLine.cpp
+++ b/src/jrd/trace/TraceCmdLine.cpp
@@ -62,11 +62,14 @@ namespace
 		static const SafeArg dummy;
 		printMsg(number, dummy, newLine);
 	}
-
+// All MessageSet instances below (MAIN_USAGE, EXAMPLES) are initialized with
+// message codes in range 3..42, which fits well within USHORT (0..65535).
+// See usages below: MAIN_USAGE{{3, 21}, {41}}, EXAMPLES{{22, 27}, {42}}.
+// If new codes are added, make sure they still fit into USHORT.
 	struct MessageSet
 	{
 		const int range[2];
-		const std::initializer_list<int> list;
+		const std::initializer_list<USHORT> list;
 
 		void print() const
 		{

--- a/src/jrd/trace/TraceCmdLine.cpp
+++ b/src/jrd/trace/TraceCmdLine.cpp
@@ -386,6 +386,8 @@ void fbtrace(UtilSvc* uSvc, TraceSvcIntf* traceSvc)
 						(Arg::Gds(isc_io_error) << Arg::Str("read") << Arg::Str(fileName) <<
 							Arg::Gds(isc_io_read_err) << Arg::OsError()).raise();
 						break;
+					default:
+						fb_assert(false);
 				}
 			}
 			else

--- a/src/jrd/trace/TraceCmdLine.cpp
+++ b/src/jrd/trace/TraceCmdLine.cpp
@@ -210,6 +210,9 @@ void fbtrace(UtilSvc* uSvc, TraceSvcIntf* traceSvc)
 				case IN_SW_TRACE_LIST:
 					usage(uSvc, isc_trace_param_act_notcompat, sw->in_sw_name, action_sw->in_sw_name);
 					break;
+				default:
+					fb_assert(false);
+					break;
 			}
 
 			if (!session.ses_config.empty())
@@ -231,6 +234,9 @@ void fbtrace(UtilSvc* uSvc, TraceSvcIntf* traceSvc)
 				case IN_SW_TRACE_LIST:
 					usage(uSvc, isc_trace_param_act_notcompat, sw->in_sw_name, action_sw->in_sw_name);
 					break;
+				default:
+					fb_assert(false);
+					break;
 			}
 
 			if (!session.ses_name.empty())
@@ -249,6 +255,9 @@ void fbtrace(UtilSvc* uSvc, TraceSvcIntf* traceSvc)
 				case IN_SW_TRACE_START:
 				case IN_SW_TRACE_LIST:
 					usage(uSvc, isc_trace_param_act_notcompat, sw->in_sw_name, action_sw->in_sw_name);
+					break;
+				default:
+					fb_assert(false);
 					break;
 			}
 
@@ -274,6 +283,9 @@ void fbtrace(UtilSvc* uSvc, TraceSvcIntf* traceSvc)
 				case IN_SW_TRACE_RESUME:
 				case IN_SW_TRACE_LIST:
 					usage(uSvc, isc_trace_param_act_notcompat, sw->in_sw_name, action_sw->in_sw_name);
+					break;
+				default:
+					fb_assert(false);
 					break;
 			}
 

--- a/src/jrd/trace/TraceCmdLine.cpp
+++ b/src/jrd/trace/TraceCmdLine.cpp
@@ -66,6 +66,7 @@ namespace
 	struct MessageSet
 	{
 		const int range[2];
+
 		const std::initializer_list<USHORT> list;
 
 		void print() const

--- a/src/jrd/trace/TraceConfigStorage.cpp
+++ b/src/jrd/trace/TraceConfigStorage.cpp
@@ -716,7 +716,7 @@ void ConfigStorage::addSession(TraceSession& session)
 	session.ses_flags |= trs_active;
 	slot->ses_flags = session.ses_flags;
 	time(&session.ses_start);
-
+	fb_assert(session.ses_start != (time_t) -1);
 	char* p = reinterpret_cast<char*> (header) + slot->offset;
 	Writer writer(p, slot->size);
 

--- a/src/jrd/trace/TraceConfigStorage.cpp
+++ b/src/jrd/trace/TraceConfigStorage.cpp
@@ -178,7 +178,8 @@ void ConfigStorage::shutdown()
 void ConfigStorage::mutexBug(int state, const char* string)
 {
 	TEXT msg[BUFFER_TINY];
-	snprintf(msg, sizeof(msg), "ConfigStorage: mutex %s error, status = %d", string, state);
+	[[maybe_unused]] const int len = snprintf(msg, sizeof(msg), "ConfigStorage: mutex %s error, status = %d", string, state);
+	fb_assert(len >= 0 && len < (int) sizeof(msg));
 	fb_utils::logAndDie(msg);
 }
 

--- a/src/jrd/trace/TraceConfigStorage.cpp
+++ b/src/jrd/trace/TraceConfigStorage.cpp
@@ -243,11 +243,13 @@ void ConfigStorage::checkAudit()
 
 		TraceSession session(*getDefaultMemoryPool());
 
-		fseek(cfgFile, 0, SEEK_END);
+		[[maybe_unused]] int fseekResult = fseek(cfgFile, 0, SEEK_END);
+		fb_assert(fseekResult == 0);
 		const long len = ftell(cfgFile);
 		if (len)
 		{
-			fseek(cfgFile, 0, SEEK_SET);
+			fseekResult = fseek(cfgFile, 0, SEEK_SET);
+			fb_assert(fseekResult == 0);
 			char* p = session.ses_config.getBuffer(len + 1);
 
 			if (fread(p, 1, len, cfgFile) != size_t(len)) {

--- a/src/jrd/trace/TraceConfigStorage.cpp
+++ b/src/jrd/trace/TraceConfigStorage.cpp
@@ -179,7 +179,7 @@ void ConfigStorage::mutexBug(int state, const char* string)
 {
 	TEXT msg[BUFFER_TINY];
 	[[maybe_unused]] const int len = snprintf(msg, sizeof(msg), "ConfigStorage: mutex %s error, status = %d", string, state);
-	fb_assert(len >= 0 && len < (int) sizeof(msg));
+	fb_assert(len >= 0 && len < static_cast<int>(sizeof(msg)));
 	fb_utils::logAndDie(msg);
 }
 
@@ -244,13 +244,13 @@ void ConfigStorage::checkAudit()
 
 		TraceSession session(*getDefaultMemoryPool());
 
-		[[maybe_unused]] int fseekResult = fseek(cfgFile, 0, SEEK_END);
-		fb_assert(fseekResult == 0);
+		[[maybe_unused]] const int resultEnd = fseek(cfgFile, 0, SEEK_END);
+		fb_assert(resultEnd == 0);
 		const long len = ftell(cfgFile);
 		if (len)
 		{
-			fseekResult = fseek(cfgFile, 0, SEEK_SET);
-			fb_assert(fseekResult == 0);
+			[[maybe_unused]] const int resultSet = fseek(cfgFile, 0, SEEK_SET);
+			fb_assert(resultSet == 0);
 			char* p = session.ses_config.getBuffer(len + 1);
 
 			if (fread(p, 1, len, cfgFile) != size_t(len)) {

--- a/src/jrd/trace/TraceLog.cpp
+++ b/src/jrd/trace/TraceLog.cpp
@@ -299,7 +299,8 @@ void TraceLog::setFullMsg(const char* str)
 void TraceLog::mutexBug(int state, const char* string)
 {
 	TEXT msg[BUFFER_TINY];
-	snprintf(msg, sizeof(msg), "TraceLog: mutex %s error, status = %d", string, state);
+	[[maybe_unused]] const int len = snprintf(msg, sizeof(msg), "TraceLog: mutex %s error, status = %d", string, state);
+	fb_assert(len >= 0 && len < (int) sizeof(msg));
 	fb_utils::logAndDie(msg);
 }
 

--- a/src/jrd/trace/TraceObjects.cpp
+++ b/src/jrd/trace/TraceObjects.cpp
@@ -684,7 +684,7 @@ TraceRuntimeStats::TraceRuntimeStats(Attachment* attachment,
 		m_info.pin_tables = m_legacyCounts.begin();
 		m_info.pin_count = m_legacyCounts.getCount();
 
-		for (MetaId i = 0; i < m_info.pin_count; i++)
+		for (FB_SIZE_T i = 0; i < m_info.pin_count; i++)
 		{
 			m_info.pin_tables[i].trc_relation_id = m_tableCounters.getObjectId(i);
 			m_info.pin_tables[i].trc_relation_name = m_tableCounters.getObjectName(i);


### PR DESCRIPTION
## Problem
- Several switch statements over enum-like fields didn't handle unexpected
  values explicitly, which could lead to silent incorrect behavior.
- Return values of `time()`, `fseek()` and `snprintf()` were ignored,
  even though their failure (or truncation, for `snprintf()`) could lead
  to incorrect behavior going unnoticed.
- A loop variable used `MetaId` (`USHORT`), a type not intended for
  holding counts, to iterate up to `m_info.pin_count` (type `size_t`),
  risking narrowing and a potential infinite loop.
- `MessageSet` used `int` for message codes that are always within a
  small fixed range, wider than necessary.

## Fix
- Added explicit `default: fb_assert(false)` branches to catch unexpected
  switch values early instead of failing silently.
- Saved the return values of `time()`, `fseek()` and `snprintf()` into
  `[[maybe_unused]]` variables and added `fb_assert` checks on them.
- Changed the loop variable type to `FB_SIZE_T` to match the type of
  `m_info.pin_count` it's compared against, avoiding narrowing.
- Changed `MessageSet` fields to `USHORT`.

## Notes
- Changing `pin_count`'s type isn't an option since `PerformanceInfo` is
  a public struct used outside this file — that would be an API change.
  Casting `pin_count` at the comparison would just hide the mismatch
  rather than fix it: `i` is used as an array index into
  `m_tableCounters`, not as a `MetaId`, so `MetaId` was the wrong type
  here regardless of `pin_count`'s type. Widening the loop variable to
  `FB_SIZE_T` fixes the actual type mismatch and removes the risk of
  overflow/infinite loop if `pin_count` ever grows beyond `USHORT` range.
- `MessageSet` fields were changed to `USHORT`. All current usages
  (`MAIN_USAGE`, `EXAMPLES`) are initialized with message codes in range
  3..42, e.g. `MAIN_USAGE{{3, 21}, {41}}`, `EXAMPLES{{22, 27}, {42}}` —
  well within `USHORT` (0..65535). If new codes are added in the future,
  make sure they still fit into `USHORT`.