### PR TITLE
Master koryukov add asserts

### DIFF
--- a/src/jrd/trace/TraceCmdLine.cpp
+++ b/src/jrd/trace/TraceCmdLine.cpp
@@ -434,6 +434,8 @@ void fbtrace(UtilSvc* uSvc, TraceSvcIntf* traceSvc)
 			case IN_SW_TRACE_RESUME:
 				usage(uSvc, isc_trace_switch_param_miss, "ID", action_sw->in_sw_name);
 				break;
+			default:
+				fb_assert(false);
 		}
 	}
 

--- a/src/jrd/trace/TraceCmdLine.cpp
+++ b/src/jrd/trace/TraceCmdLine.cpp
@@ -386,6 +386,8 @@ void fbtrace(UtilSvc* uSvc, TraceSvcIntf* traceSvc)
 						(Arg::Gds(isc_io_error) << Arg::Str("read") << Arg::Str(fileName) <<
 							Arg::Gds(isc_io_read_err) << Arg::OsError()).raise();
 						break;
+					default:
+						fb_assert(false);
 				}
 			}
 			else

--- a/src/jrd/trace/TraceCmdLine.cpp
+++ b/src/jrd/trace/TraceCmdLine.cpp
@@ -210,6 +210,9 @@ void fbtrace(UtilSvc* uSvc, TraceSvcIntf* traceSvc)
 				case IN_SW_TRACE_LIST:
 					usage(uSvc, isc_trace_param_act_notcompat, sw->in_sw_name, action_sw->in_sw_name);
 					break;
+				default:
+					fb_assert(false);
+					break;
 			}
 
 			if (!session.ses_config.empty())
@@ -231,6 +234,9 @@ void fbtrace(UtilSvc* uSvc, TraceSvcIntf* traceSvc)
 				case IN_SW_TRACE_LIST:
 					usage(uSvc, isc_trace_param_act_notcompat, sw->in_sw_name, action_sw->in_sw_name);
 					break;
+				default:
+					fb_assert(false);
+					break;
 			}
 
 			if (!session.ses_name.empty())
@@ -249,6 +255,9 @@ void fbtrace(UtilSvc* uSvc, TraceSvcIntf* traceSvc)
 				case IN_SW_TRACE_START:
 				case IN_SW_TRACE_LIST:
 					usage(uSvc, isc_trace_param_act_notcompat, sw->in_sw_name, action_sw->in_sw_name);
+					break;
+				default:
+					fb_assert(false);
 					break;
 			}
 
@@ -274,6 +283,9 @@ void fbtrace(UtilSvc* uSvc, TraceSvcIntf* traceSvc)
 				case IN_SW_TRACE_RESUME:
 				case IN_SW_TRACE_LIST:
 					usage(uSvc, isc_trace_param_act_notcompat, sw->in_sw_name, action_sw->in_sw_name);
+					break;
+				default:
+					fb_assert(false);
 					break;
 			}
 

--- a/src/jrd/trace/TraceConfigStorage.cpp
+++ b/src/jrd/trace/TraceConfigStorage.cpp
@@ -716,7 +716,7 @@ void ConfigStorage::addSession(TraceSession& session)
 	session.ses_flags |= trs_active;
 	slot->ses_flags = session.ses_flags;
 	time(&session.ses_start);
-
+	fb_assert(session.ses_start != (time_t) -1);
 	char* p = reinterpret_cast<char*> (header) + slot->offset;
 	Writer writer(p, slot->size);
 

--- a/src/jrd/trace/TraceConfigStorage.cpp
+++ b/src/jrd/trace/TraceConfigStorage.cpp
@@ -178,7 +178,8 @@ void ConfigStorage::shutdown()
 void ConfigStorage::mutexBug(int state, const char* string)
 {
 	TEXT msg[BUFFER_TINY];
-	snprintf(msg, sizeof(msg), "ConfigStorage: mutex %s error, status = %d", string, state);
+	[[maybe_unused]] const int len = snprintf(msg, sizeof(msg), "ConfigStorage: mutex %s error, status = %d", string, state);
+	fb_assert(len >= 0 && len < (int) sizeof(msg));
 	fb_utils::logAndDie(msg);
 }
 

--- a/src/jrd/trace/TraceConfigStorage.cpp
+++ b/src/jrd/trace/TraceConfigStorage.cpp
@@ -243,11 +243,13 @@ void ConfigStorage::checkAudit()
 
 		TraceSession session(*getDefaultMemoryPool());
 
-		fseek(cfgFile, 0, SEEK_END);
+		[[maybe_unused]] int fseekResult = fseek(cfgFile, 0, SEEK_END);
+		fb_assert(fseekResult == 0);
 		const long len = ftell(cfgFile);
 		if (len)
 		{
-			fseek(cfgFile, 0, SEEK_SET);
+			fseekResult = fseek(cfgFile, 0, SEEK_SET);
+			fb_assert(fseekResult == 0);
 			char* p = session.ses_config.getBuffer(len + 1);
 
 			if (fread(p, 1, len, cfgFile) != size_t(len)) {

--- a/src/jrd/trace/TraceConfigStorage.cpp
+++ b/src/jrd/trace/TraceConfigStorage.cpp
@@ -179,7 +179,7 @@ void ConfigStorage::mutexBug(int state, const char* string)
 {
 	TEXT msg[BUFFER_TINY];
 	[[maybe_unused]] const int len = snprintf(msg, sizeof(msg), "ConfigStorage: mutex %s error, status = %d", string, state);
-	fb_assert(len >= 0 && len < (int) sizeof(msg));
+	fb_assert(len >= 0 && len < static_cast<int>(sizeof(msg)));
 	fb_utils::logAndDie(msg);
 }
 
@@ -244,13 +244,13 @@ void ConfigStorage::checkAudit()
 
 		TraceSession session(*getDefaultMemoryPool());
 
-		[[maybe_unused]] int fseekResult = fseek(cfgFile, 0, SEEK_END);
-		fb_assert(fseekResult == 0);
+		[[maybe_unused]] const int resultEnd = fseek(cfgFile, 0, SEEK_END);
+		fb_assert(resultEnd == 0);
 		const long len = ftell(cfgFile);
 		if (len)
 		{
-			fseekResult = fseek(cfgFile, 0, SEEK_SET);
-			fb_assert(fseekResult == 0);
+			[[maybe_unused]] const int resultSet = fseek(cfgFile, 0, SEEK_SET);
+			fb_assert(resultSet == 0);
 			char* p = session.ses_config.getBuffer(len + 1);
 
 			if (fread(p, 1, len, cfgFile) != size_t(len)) {

--- a/src/jrd/trace/TraceLog.cpp
+++ b/src/jrd/trace/TraceLog.cpp
@@ -299,7 +299,8 @@ void TraceLog::setFullMsg(const char* str)
 void TraceLog::mutexBug(int state, const char* string)
 {
 	TEXT msg[BUFFER_TINY];
-	snprintf(msg, sizeof(msg), "TraceLog: mutex %s error, status = %d", string, state);
+	[[maybe_unused]] const int len = snprintf(msg, sizeof(msg), "TraceLog: mutex %s error, status = %d", string, state);
+	fb_assert(len >= 0 && len < (int) sizeof(msg));
 	fb_utils::logAndDie(msg);
 }
 


### PR DESCRIPTION
Problem

Several switch statements over enum-like fields, and return values of
time(), fseek() and snprintf(), were not checked, which could lead to
silent incorrect behavior.

Fix

* Added explicit `default: fb_assert(false)` branches to switch
statements to catch unexpected values early.
* Saved the return values of `time()`, `fseek()` and `snprintf()` into
`[[maybe_unused]]` variables and added `fb_assert` checks on them.