### PR TITLE
Master koryukov fix types

### DIFF
--- a/src/jrd/trace/TraceCmdLine.cpp
+++ b/src/jrd/trace/TraceCmdLine.cpp
@@ -69,6 +69,7 @@ namespace
 	struct MessageSet
 	{
 		const int range[2];
+
 		const std::initializer_list<USHORT> list;
 
 		void print() const

--- a/src/jrd/trace/TraceCmdLine.cpp
+++ b/src/jrd/trace/TraceCmdLine.cpp
@@ -62,10 +62,7 @@ namespace
 		static const SafeArg dummy;
 		printMsg(number, dummy, newLine);
 	}
-// All MessageSet instances below (MAIN_USAGE, EXAMPLES) are initialized with
-// message codes in range 3..42, which fits well within USHORT (0..65535).
-// See usages below: MAIN_USAGE{{3, 21}, {41}}, EXAMPLES{{22, 27}, {42}}.
-// If new codes are added, make sure they still fit into USHORT.
+
 	struct MessageSet
 	{
 		const int range[2];

--- a/src/jrd/trace/TraceCmdLine.cpp
+++ b/src/jrd/trace/TraceCmdLine.cpp
@@ -62,11 +62,14 @@ namespace
 		static const SafeArg dummy;
 		printMsg(number, dummy, newLine);
 	}
-
+// All MessageSet instances below (MAIN_USAGE, EXAMPLES) are initialized with
+// message codes in range 3..42, which fits well within USHORT (0..65535).
+// See usages below: MAIN_USAGE{{3, 21}, {41}}, EXAMPLES{{22, 27}, {42}}.
+// If new codes are added, make sure they still fit into USHORT.
 	struct MessageSet
 	{
 		const int range[2];
-		const std::initializer_list<int> list;
+		const std::initializer_list<USHORT> list;
 
 		void print() const
 		{

--- a/src/jrd/trace/TraceObjects.cpp
+++ b/src/jrd/trace/TraceObjects.cpp
@@ -684,7 +684,7 @@ TraceRuntimeStats::TraceRuntimeStats(Attachment* attachment,
 		m_info.pin_tables = m_legacyCounts.begin();
 		m_info.pin_count = m_legacyCounts.getCount();
 
-		for (MetaId i = 0; i < m_info.pin_count; i++)
+		for (FB_SIZE_T i = 0; i < m_info.pin_count; i++)
 		{
 			m_info.pin_tables[i].trc_relation_id = m_tableCounters.getObjectId(i);
 			m_info.pin_tables[i].trc_relation_name = m_tableCounters.getObjectName(i);


### PR DESCRIPTION
Problem

* A loop variable used `MetaId` (`USHORT`), a type not intended for
holding counts, to iterate up to `m_info.pin_count` (type `size_t`),
risking narrowing and a potential infinite loop.
* `MessageSet` used `int` for message codes that are always within a
small fixed range, wider than necessary.

Fix

* Changed the loop variable type to `FB_SIZE_T` to match the type of
`m_info.pin_count` it's compared against, avoiding narrowing.
* Changed `MessageSet` fields to `USHORT`.

Notes

* Changing `pin_count`'s type isn't an option since `PerformanceInfo` is
a public struct used outside this file — that would be an API change.
Casting `pin_count` at the comparison would just hide the mismatch
rather than fix it: `i` is used as an array index into
`m_tableCounters`, not as a `MetaId`, so `MetaId` was the wrong type
here regardless of `pin_count`'s type. Widening the loop variable to
`FB_SIZE_T` fixes the actual type mismatch and removes the risk of
overflow/infinite loop if `pin_count` ever grows beyond `USHORT` range.
* `MessageSet` fields were changed to `USHORT`. All current usages
(`MAIN_USAGE`, `EXAMPLES`) are initialized with message codes in range
3..42, e.g. `MAIN_USAGE{{3, 21}, {41}}`, `EXAMPLES{{22, 27}, {42}}` —
well within `USHORT` (0..65535). If new codes are added in the future,
make sure they still fit into `USHORT`.